### PR TITLE
refactor: :construction: add starknet_version and eth_l1_gas_price

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,5 @@
     "titleBar.activeBackground": "#0D474E",
     "titleBar.activeForeground": "#F2FCFD"
   },
-  "conventionalCommits.scopes": [
-    "spec_version"
-  ]
+  "conventionalCommits.scopes": ["spec_version"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- feat(rpc): add starknet_version and eth_l1_gas_fee on block header
 - fix(spec_version): spec version now returning 0.5.1
 - chore: feature flags for avail and celestia DA
 - feat(rpc): added support for v0.5.1 JSON-RPC specs

--- a/crates/client/commitment-state-diff/src/lib.rs
+++ b/crates/client/commitment-state-diff/src/lib.rs
@@ -264,8 +264,8 @@ pub async fn verify_l2(mut rx: mpsc::Receiver<BlockDAData>) {
 //             .class_hash_to_compiled_class_hash
 //             .iter()
 //             .map(|(_, compiled_class_hash)| {
-//                 
-// calculate_class_commitment_leaf_hash::<PoseidonHasher>((*compiled_class_hash).into())            
+//
+// calculate_class_commitment_leaf_hash::<PoseidonHasher>((*compiled_class_hash).into())
 // })             .collect();
 //         calculate_class_commitment_tree_root_hash::<PoseidonHasher>(&class_hashes)
 //     };

--- a/crates/client/deoxys/Cargo.toml
+++ b/crates/client/deoxys/Cargo.toml
@@ -50,10 +50,10 @@ hex = "0.4"
 mc-commitment-state-diff = { workspace = true }
 mp-block = { workspace = true }
 mp-commitments = { workspace = true }
+mp-fee = { workspace = true }
 mp-felt = { workspace = true }
 mp-hashers = { workspace = true }
 mp-transactions = { workspace = true, features = ["client"] }
-mp-fee = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 sc-consensus-manual-seal.workspace = true
 validator = { workspace = true, features = ["derive"] }

--- a/crates/client/deoxys/src/convert.rs
+++ b/crates/client/deoxys/src/convert.rs
@@ -1,8 +1,8 @@
 //! Converts types from [`starknet_providers`] to madara's expected types.
 
+use mp_fee::ResourcePrice;
 use mp_felt::Felt252Wrapper;
 use starknet_api::hash::StarkFelt;
-use mp_fee::ResourcePrice;
 use starknet_ff::FieldElement;
 use starknet_providers::sequencer::models as p;
 
@@ -142,10 +142,9 @@ fn l1_handler_transaction(tx: &p::L1HandlerTransaction) -> mp_transactions::Hand
 /// If the string contains more than 31 bytes, the function panics.
 fn starknet_version(version: &Option<String>) -> Felt252Wrapper {
     let ret = match version {
-        Some(version) => Felt252Wrapper::try_from(
-            version
-            .as_bytes())
-            .expect("Failed to convert version to felt: string is too long"),
+        Some(version) => {
+            Felt252Wrapper::try_from(version.as_bytes()).expect("Failed to convert version to felt: string is too long")
+        }
         None => Felt252Wrapper::ZERO,
     };
     println!("Starknet version: {}", ret.from_utf8().unwrap());

--- a/crates/client/deoxys/src/convert.rs
+++ b/crates/client/deoxys/src/convert.rs
@@ -1,5 +1,6 @@
 //! Converts types from [`starknet_providers`] to madara's expected types.
 
+use mp_felt::Felt252Wrapper;
 use starknet_api::hash::StarkFelt;
 use mp_fee::ResourcePrice;
 use starknet_ff::FieldElement;
@@ -11,7 +12,8 @@ pub fn block(block: &p::Block) -> mp_block::Block {
     let block_number = block.block_number.expect("no block number provided");
     let sequencer_address = block.sequencer_address.map_or(contract_address(FieldElement::ZERO), contract_address);
     let (transaction_commitment, event_commitment) = commitments(&transactions, &events, block_number);
-    let l1_gas_price = ResourcePrice::default();
+    let l1_gas_price = resource_price(block.eth_l1_gas_price);
+    let protocol_version = starknet_version(&block.starknet_version);
 
     let header = mp_block::Header {
         parent_block_hash: felt(block.parent_block_hash),
@@ -23,7 +25,7 @@ pub fn block(block: &p::Block) -> mp_block::Block {
         transaction_commitment,
         event_count: events.len() as u128,
         event_commitment,
-        protocol_version: 0,
+        protocol_version,
         l1_gas_price,
         extra_data: block.block_hash.map(|h| sp_core::U256::from_big_endian(&h.to_bytes_be())),
     };
@@ -136,8 +138,29 @@ fn l1_handler_transaction(tx: &p::L1HandlerTransaction) -> mp_transactions::Hand
     }
 }
 
+/// Converts a starknet version string to a felt value.
+/// If the string contains more than 31 bytes, the function panics.
+fn starknet_version(version: &Option<String>) -> Felt252Wrapper {
+    let ret = match version {
+        Some(version) => Felt252Wrapper::try_from(
+            version
+            .as_bytes())
+            .expect("Failed to convert version to felt: string is too long"),
+        None => Felt252Wrapper::ZERO,
+    };
+    println!("Starknet version: {}", ret.from_utf8().unwrap());
+    ret
+}
+
 fn fee(felt: starknet_ff::FieldElement) -> u128 {
     felt.try_into().expect("Value out of range for u128")
+}
+
+fn resource_price(eth_l1_gas_price: starknet_ff::FieldElement) -> ResourcePrice {
+    ResourcePrice {
+        price_in_strk: None,
+        price_in_wei: fee(eth_l1_gas_price).try_into().expect("Value out of range for u64"),
+    }
 }
 
 fn events(receipts: &[p::ConfirmedTransactionReceipt]) -> Vec<starknet_api::transaction::Event> {

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -876,7 +876,7 @@ where
             timestamp: starknet_block.header().block_timestamp,
             sequencer_address: Felt252Wrapper::from(starknet_block.header().sequencer_address).into(),
             l1_gas_price: starknet_block.header().l1_gas_price.into(),
-            starknet_version: starknet_version.to_string(),
+            starknet_version: starknet_version.from_utf8().expect("starknet version should be a valid utf8 string"),
         };
 
         Ok(MaybePendingBlockWithTxHashes::Block(block_with_tx_hashes))
@@ -1124,7 +1124,7 @@ where
             sequencer_address: Felt252Wrapper::from(starknet_block.header().sequencer_address).into(),
             transactions,
             l1_gas_price: starknet_block.header().l1_gas_price.into(),
-            starknet_version: starknet_version.to_string(),
+            starknet_version: starknet_version.from_utf8().expect("starknet version should be a valid utf8 string"),
         };
 
         Ok(MaybePendingBlockWithTxs::Block(block_with_txs))

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -50,10 +50,10 @@ use starknet_core::types::{
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction, ContractClass,
     DeclareTransactionReceipt, DeclareTransactionResult, DeployAccountTransactionReceipt,
     DeployAccountTransactionResult, DeployTransactionReceipt, EventFilterWithPage, EventsPage, ExecutionResult,
-    FeeEstimate, FieldElement, FunctionCall, InvokeTransactionReceipt, InvokeTransactionResult,
+    FeeEstimate, FieldElement, FunctionCall, Hash256, InvokeTransactionReceipt, InvokeTransactionResult,
     L1HandlerTransactionReceipt, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
     MaybePendingTransactionReceipt, StateDiff, StateUpdate, SyncStatus, SyncStatusType, Transaction,
-    TransactionExecutionStatus, TransactionFinalityStatus, TransactionReceipt, Hash256
+    TransactionExecutionStatus, TransactionFinalityStatus, TransactionReceipt,
 };
 use starknet_core::utils::get_selector_from_name;
 

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -166,7 +166,7 @@ pub mod pallet {
         #[pallet::constant]
         type ValidateMaxNSteps: Get<u32>;
         #[pallet::constant]
-        type ProtocolVersion: Get<u8>;
+        type ProtocolVersion: Get<Felt252Wrapper>;
         #[pallet::constant]
         type ChainId: Get<Felt252Wrapper>;
         #[pallet::constant]
@@ -1049,7 +1049,7 @@ impl<T: Config> Pallet<T> {
                     transaction_commitment.into(),
                     events.len() as u128,
                     event_commitment.into(),
-                    protocol_version,
+                    protocol_version.into(),
                     l1_gas_price,
                     extra_data,
                 ),

--- a/crates/primitives/block/src/header.rs
+++ b/crates/primitives/block/src/header.rs
@@ -70,7 +70,7 @@ pub struct Header {
     /// A commitment to the events produced in this block
     pub event_commitment: StarkHash,
     /// The version of the Starknet protocol used when creating this block
-    pub protocol_version: u8,
+    pub protocol_version: Felt252Wrapper,
     /// l1 gas price for this block
     pub l1_gas_price: ResourcePrice,
     /// Extraneous data that might be useful for running transactions
@@ -91,7 +91,7 @@ impl Header {
         transaction_commitment: StarkHash,
         event_count: u128,
         event_commitment: StarkHash,
-        protocol_version: u8,
+        protocol_version: Felt252Wrapper,
         l1_gas_price: ResourcePrice,
         extra_data: Option<U256>,
     ) -> Self {

--- a/crates/primitives/transactions/src/compute_hash.rs
+++ b/crates/primitives/transactions/src/compute_hash.rs
@@ -20,7 +20,12 @@ const INVOKE_PREFIX: &[u8] = b"invoke";
 const L1_HANDLER_PREFIX: &[u8] = b"l1_handler";
 
 pub trait ComputeTransactionHash {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, block_number: Option<u64>,) -> Felt252Wrapper;
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        block_number: Option<u64>,
+    ) -> Felt252Wrapper;
 }
 
 fn convert_calldata(data: &[Felt252Wrapper]) -> &[FieldElement] {
@@ -30,7 +35,12 @@ fn convert_calldata(data: &[Felt252Wrapper]) -> &[FieldElement] {
 }
 
 impl ComputeTransactionHash for InvokeTransactionV0 {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, block_number: Option<u64>,) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         let prefix = FieldElement::from_byte_slice_be(INVOKE_PREFIX).unwrap();
         let version = if offset_version { SIMULATE_TX_VERSION_OFFSET } else { FieldElement::ZERO };
         let contract_address = self.contract_address.into();
@@ -59,7 +69,12 @@ impl ComputeTransactionHash for InvokeTransactionV0 {
 }
 
 impl ComputeTransactionHash for InvokeTransactionV1 {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, _block_number: Option<u64>,) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        _block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         let prefix = FieldElement::from_byte_slice_be(INVOKE_PREFIX).unwrap();
         let version = if offset_version { SIMULATE_TX_VERSION_OFFSET + FieldElement::ONE } else { FieldElement::ONE };
         let sender_address = self.sender_address.into();
@@ -84,7 +99,12 @@ impl ComputeTransactionHash for InvokeTransactionV1 {
 }
 
 impl ComputeTransactionHash for InvokeTransaction {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         match self {
             InvokeTransaction::V0(tx) => tx.compute_hash::<H>(chain_id, offset_version, block_number),
             InvokeTransaction::V1(tx) => tx.compute_hash::<H>(chain_id, offset_version, block_number),
@@ -93,7 +113,12 @@ impl ComputeTransactionHash for InvokeTransaction {
 }
 
 impl ComputeTransactionHash for DeclareTransactionV0 {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, _block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        _block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         let prefix = FieldElement::from_byte_slice_be(DECLARE_PREFIX).unwrap();
         let version = if offset_version { SIMULATE_TX_VERSION_OFFSET } else { FieldElement::ZERO };
         let sender_address = self.sender_address.into();
@@ -118,7 +143,12 @@ impl ComputeTransactionHash for DeclareTransactionV0 {
 }
 
 impl ComputeTransactionHash for DeclareTransactionV1 {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, _block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        _block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         let prefix = FieldElement::from_byte_slice_be(DECLARE_PREFIX).unwrap();
         let version = if offset_version { SIMULATE_TX_VERSION_OFFSET + FieldElement::ONE } else { FieldElement::ONE };
         let sender_address = self.sender_address.into();
@@ -143,7 +173,12 @@ impl ComputeTransactionHash for DeclareTransactionV1 {
 }
 
 impl ComputeTransactionHash for DeclareTransactionV2 {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, _block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        _block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         let prefix = FieldElement::from_byte_slice_be(DECLARE_PREFIX).unwrap();
         let version = if offset_version { SIMULATE_TX_VERSION_OFFSET + FieldElement::TWO } else { FieldElement::TWO };
         let sender_address = self.sender_address.into();
@@ -170,7 +205,12 @@ impl ComputeTransactionHash for DeclareTransactionV2 {
 }
 
 impl ComputeTransactionHash for DeclareTransaction {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, _block_number: Option<u64>,) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        _block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         match self {
             DeclareTransaction::V0(tx) => tx.compute_hash::<H>(chain_id, offset_version, None),
             DeclareTransaction::V1(tx) => tx.compute_hash::<H>(chain_id, offset_version, None),
@@ -180,7 +220,12 @@ impl ComputeTransactionHash for DeclareTransaction {
 }
 
 impl ComputeTransactionHash for DeployAccountTransaction {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, _block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        _block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         let chain_id = chain_id.into();
         let contract_address = self.get_account_address();
 
@@ -323,7 +368,12 @@ impl DeployTransaction {
 }
 
 impl ComputeTransactionHash for HandleL1MessageTransaction {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         let prefix = FieldElement::from_byte_slice_be(L1_HANDLER_PREFIX).unwrap();
         let invoke_prefix = FieldElement::from_byte_slice_be(INVOKE_PREFIX).unwrap();
         let version = if offset_version { SIMULATE_TX_VERSION_OFFSET } else { FieldElement::ZERO };
@@ -369,7 +419,12 @@ impl ComputeTransactionHash for HandleL1MessageTransaction {
 }
 
 impl ComputeTransactionHash for Transaction {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         match self {
             Transaction::Declare(tx) => tx.compute_hash::<H>(chain_id, offset_version, block_number),
             Transaction::DeployAccount(tx) => tx.compute_hash::<H>(chain_id, offset_version, block_number),
@@ -381,7 +436,12 @@ impl ComputeTransactionHash for Transaction {
 }
 
 impl ComputeTransactionHash for UserTransaction {
-    fn compute_hash<H: HasherT>(&self, chain_id: Felt252Wrapper, offset_version: bool, _block_number: Option<u64>) -> Felt252Wrapper {
+    fn compute_hash<H: HasherT>(
+        &self,
+        chain_id: Felt252Wrapper,
+        offset_version: bool,
+        _block_number: Option<u64>,
+    ) -> Felt252Wrapper {
         match self {
             UserTransaction::Declare(tx, _) => tx.compute_hash::<H>(chain_id, offset_version, None),
             UserTransaction::DeployAccount(tx) => tx.compute_hash::<H>(chain_id, offset_version, None),


### PR DESCRIPTION
- add starknet_version and eth_l1_gas_price in DB
- change type of starknet_version from u8 to Felt252Wrapper

# Pull Request type

- Feature


## What is the current behavior?

Resolves: #25 #26

## What is the new behavior?

- The block headers contain the starknet _version and eth_l1_gas_fee fields

## Does this introduce a breaking change?

No

## Other information

