### PR TITLE
Implemented `starknet_getClassAt` and `starknet_getClassHashAt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Madara Changelog
 
 ## Next release
 
+- fix(class): #32 #33 #34
 - fix(class): #116
 - feat(class): download classes from sequencer
 - feat: update and store highest block hash and number from sequencer

--- a/crates/client/deoxys/Cargo.toml
+++ b/crates/client/deoxys/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = "0.10.0"
 futures = { workspace = true, default-features = true }
 hex = "0.4"
 indexmap = { workspace = true }
+itertools = { workspace = true }
 log = { version = "0.4.14" }
 mockito = { workspace = true }
 rand = { version = "0.8.5" }

--- a/crates/client/deoxys/src/l2.rs
+++ b/crates/client/deoxys/src/l2.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use mc_storage::OverrideHandle;
 use mp_block::state_update::StateUpdateWrapper;
@@ -350,6 +351,7 @@ fn aggregate_classes(state_update: &StateUpdate) -> Vec<&FieldElement> {
                 .map(|DeclaredContract { class_hash, compiled_class_hash: _ }| class_hash),
         )
         .chain(state_update.state_diff.old_declared_contracts.iter().map(|class_hash| class_hash))
+        .unique()
         .collect()
 }
 

--- a/crates/client/deoxys/src/l2.rs
+++ b/crates/client/deoxys/src/l2.rs
@@ -106,6 +106,7 @@ pub struct BlockHashEquivalence {
 
 impl BlockHashEquivalence {
     async fn new(state_update: &StateUpdate, block_number: u64, rpc_port: u16) -> Self {
+        // TODO: use an actual Substrate client to convert from Madara to Substrate block hash
         let block_hash_madara = state_update.block_hash.unwrap();
         let block_hash_substrate = &get_block_hash_by_number(rpc_port, block_number).await;
 
@@ -262,8 +263,7 @@ async fn fetch_class_update(
     block_number: u64,
     rpc_port: u16,
 ) -> Result<Vec<ContractClassData>, String> {
-    // defaults to downloading ALL classes if a substrate block hash could not be
-    // determined
+    // defaults to downloading ALL classes if a substrate block hash could not be determined
     let block_hash = BlockHashEquivalence::new(state_update, block_number - 1, rpc_port).await;
     let missing_classes = match block_hash.substrate {
         Some(block_hash_substrate) => fetch_missing_classes(state_update, overrides, block_hash_substrate),
@@ -276,8 +276,7 @@ async fn fetch_class_update(
         set
     });
 
-    // WARNING: all class downloads will abort if even a single class fails to
-    // download.
+    // WARNING: all class downloads will abort if even a single class fails to download.
     let mut classes = vec![];
     while let Some(res) = task_set.join_next().await {
         match res {
@@ -299,13 +298,13 @@ async fn fetch_class_update(
 }
 
 /// Downloads a class definition from the Starknet sequencer. Note that because
-/// of the current type hell this needs to be converted into a blockifier
-/// equivalent
+/// of the current type hell this needs to be converted into a blockifier equivalent
 async fn download_class(
     class_hash: FieldElement,
     block_hash: FieldElement,
     provider: Arc<SequencerGatewayProvider>,
 ) -> anyhow::Result<ContractClassData> {
+    log::info!("💾 Downloading class {class_hash:#x}");
     let core_class = provider.get_class(BlockIdCore::Hash(block_hash), class_hash).await?;
 
     // Core classes have to be converted into Blockifier classes to gain support

--- a/crates/client/storage/src/overrides/mod.rs
+++ b/crates/client/storage/src/overrides/mod.rs
@@ -74,6 +74,7 @@ pub trait StorageOverride<B: BlockT>: Send + Sync {
         block_hash: B::Hash,
         contract_class_hash: ClassHash,
     ) -> Option<ContractClass>;
+    fn contract_abi_by_address(&self, block_hash: B::Hash, address: ContractAddress) -> Option<ContractAbi>;
     /// Return the contract abi for a provided class_hash and block hash
     fn contract_abi_by_class_hash(&self, block_hash: B::Hash, contract_class_hash: ClassHash) -> Option<ContractAbi>;
     /// Returns the nonce for a provided contract address and block hash.
@@ -169,6 +170,27 @@ where
         contract_class_hash: ClassHash,
     ) -> Option<ContractClass> {
         self.client.runtime_api().contract_class_by_class_hash(block_hash, contract_class_hash).ok()?
+    }
+
+    // Use the runtime api to fetch the contract ABI at the provided address for the provided block.
+    // # Arguments
+    //
+    // * `block_hash` - The block hash
+    // * `address` - The address to fetch the class hash for
+    //
+    // # Returns
+    // * `Some(class_abi)` - The contract ABI at the provided address for the provided block
+    fn contract_abi_by_address(
+        &self,
+        block_hash: <B as BlockT>::Hash,
+        address: ContractAddress,
+    ) -> Option<ContractAbi> {
+        let api = self.client.runtime_api();
+
+        let contract_class_hash = api.contract_class_hash_by_address(block_hash, address).ok()?;
+        let contract_abi = api.contract_abi_by_class_hash(block_hash, contract_class_hash).ok()?;
+
+        contract_abi
     }
 
     /// Return the contract ABI for a provided class_hash and block hash.

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -118,6 +118,15 @@ where
         )
     }
 
+    fn contract_abi_by_address(
+        &self,
+        block_hash: <B as BlockT>::Hash,
+        address: ContractAddress,
+    ) -> Option<ContractAbi> {
+        let contract_class_hash = self.contract_class_hash_by_address(block_hash, address)?;
+        self.contract_abi_by_class_hash(block_hash, contract_class_hash)
+    }
+
     fn contract_abi_by_class_hash(
         &self,
         block_hash: <B as BlockT>::Hash,

--- a/crates/primitives/contract/src/class.rs
+++ b/crates/primitives/contract/src/class.rs
@@ -128,7 +128,7 @@ pub mod convert {
                 r#type: AbiFunctionTypeWrapper::from(abi_function_entry.r#type),
                 name: abi_function_entry.name,
                 inputs: abi_function_entry.inputs.iter().map(|v| AbiTypedParameterWrapper::from(v.clone())).collect(),
-                outputs: abi_function_entry.inputs.iter().map(|v| AbiTypedParameterWrapper::from(v.clone())).collect(),
+                outputs: abi_function_entry.outputs.iter().map(|v| AbiTypedParameterWrapper::from(v.clone())).collect(),
                 state_mutability: abi_function_entry
                     .state_mutability
                     .map(|v| AbiFunctionStateMutabilityWrapper::from(v)),

--- a/crates/primitives/convert/src/contract.rs
+++ b/crates/primitives/convert/src/contract.rs
@@ -185,7 +185,7 @@ fn to_legacy_entry_points_by_type(
 
     let constructor = collect_entry_points(entries, EntryPointType::Constructor)?;
     let external = collect_entry_points(entries, EntryPointType::External)?;
-    let l1_handler = collect_entry_points(entries, EntryPointType::L1Handler)?;
+    let l1_handler = collect_entry_points(entries, EntryPointType::L1Handler).unwrap_or_default();
 
     Ok(LegacyEntryPointsByType { constructor, external, l1_handler })
 }

--- a/crates/primitives/convert/src/contract.rs
+++ b/crates/primitives/convert/src/contract.rs
@@ -183,7 +183,7 @@ fn to_legacy_entry_points_by_type(
             .collect::<Result<Vec<LegacyContractEntryPoint>, FromByteArrayError>>()?)
     }
 
-    let constructor = collect_entry_points(entries, EntryPointType::Constructor)?;
+    let constructor = collect_entry_points(entries, EntryPointType::Constructor).unwrap_or_default();
     let external = collect_entry_points(entries, EntryPointType::External)?;
     let l1_handler = collect_entry_points(entries, EntryPointType::L1Handler).unwrap_or_default();
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [`get_class_hash_at`](https://github.com/KasarLabs/deoxys/blob/a856f047757a20431c29df36e4a86512ad63f8ce/crates/client/rpc/src/lib.rs#L713) has been marked as _TODO_ and does not return.
- [`get_class_at`](https://github.com/KasarLabs/deoxys/blob/a856f047757a20431c29df36e4a86512ad63f8ce/crates/client/rpc/src/lib.rs#L817) has been marked as _TODO_ and does not retrieve the correct contract ABI.
- Contract ABI has incorrect values in ABI function `output` field.
- Failed blockifier to starknet-core conversion on contrat classes which did not define an `L1_HANDLER` or `CONSTRUCTOR` in their entrypoints.

Resolves: #32 #33 #34

## What is the new behavior?

- Contract ABI can now be retrieved based on contract address, not just class hash.
- `starknet_getClassHashAt` retrieves the correct class hash.
- `starknet_getClassAt` retrieves the correct class and ABI.
- ABI function `output` field now has the correct values (was previously using the value of ABI function `input` field).
- blockifier to starknet-core contract class conversion now works even if `L1_HANDLER` or `CONSTRUCTOR` is not defined.
- Added info log output for when a class is being downloaded.

## Does this introduce a breaking change?

No changes have been made to class or ABI storage, so there is no need to synchronize the database

## Other information

> :warning: Note that due to how the genesis block is currently being stored, contract address to class equivalences relations are not being inserted for block 0. This causes issues for `starknet_getClassHashAt` and `starknet_getClassAt` on any class/contract defined on block 0. See #54 for more details.

`starknet_getClass`, `starknet_getClassHashAt` and `starknet_getClassAt` were briefly tested on the following classes:

- [0x010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8](https://starkscan.co/class/0x010455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8)
- [0x07595b4f7d50010ceb00230d8b5656e3c3dd201b6df35d805d3f2988c69a1432](https://starkscan.co/class/0x07595b4f7d50010ceb00230d8b5656e3c3dd201b6df35d805d3f2988c69a1432)
- [0x071c3c99f5cf76fc19945d4b8b7d34c7c5528f22730d56192b50c6bbfd338a64](https://starkscan.co/class/0x071c3c99f5cf76fc19945d4b8b7d34c7c5528f22730d56192b50c6bbfd338a64)
- [0x07543f8eb21f10b1827a495084697a519274ac9c1a1fbf931bac40133a6b9c15](https://starkscan.co/class/0x07543f8eb21f10b1827a495084697a519274ac9c1a1fbf931bac40133a6b9c15)
- [0x074a7ed7f1236225600f355efe70812129658c82c295ff0f8307b3fad4bf09a9](https://starkscan.co/class/0x074a7ed7f1236225600f355efe70812129658c82c295ff0f8307b3fad4bf09a9)

More tests will need to follow in [Ditto](https://github.com/kasarlabs/ditto).

> :warning: Note that there still appears to be a deserialization issue at block `20731`. This is likely to be similar to #116.