### PR TITLE
refactor: :recycle: Updated storage diff reprensentation in the db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,7 @@ starknet-e2e-test/contracts/build
 # vscode settings
 .vscode/settings.json
 
+# rpc output
+output*
+
 tmp/

--- a/crates/client/commitment-state-diff/src/lib.rs
+++ b/crates/client/commitment-state-diff/src/lib.rs
@@ -17,7 +17,7 @@ use sp_runtime::traits::{Block as BlockT, Header};
 use starknet_api::api_core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, PatriciaKey};
 use starknet_api::block::BlockHash;
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{StorageKey as StarknetStorageKey, ThinStateDiff};
+use starknet_api::state::ThinStateDiff;
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -178,24 +178,26 @@ where
             commitment_state_diff.nonces.insert(contract_address, nonce);
             accessed_addrs.insert(contract_address);
         } else if prefix == *SN_STORAGE_PREFIX {
-            let contract_address =
-                ContractAddress(PatriciaKey(StarkFelt(full_storage_key.0[32..64].try_into().unwrap())));
-            let storage_key = StarknetStorageKey(PatriciaKey(StarkFelt(full_storage_key.0[64..].try_into().unwrap())));
-            // `change` is safe to unwrap as `StorageView` storage is `ValueQuery`
-            let value = StarkFelt(change.unwrap().0.clone().try_into().unwrap());
+            // let contract_address =
+            //     ContractAddress(PatriciaKey(StarkFelt(full_storage_key.0[32..64].try_into().
+            // unwrap()))); let storage_key =
+            // StarknetStorageKey(PatriciaKey(StarkFelt(full_storage_key.0[64..].try_into().
+            // unwrap()))); // `change` is safe to unwrap as `StorageView` storage is
+            // `ValueQuery` let value =
+            // StarkFelt(change.unwrap().0.clone().try_into().unwrap());
 
-            match commitment_state_diff.storage_diffs.get_mut(&contract_address) {
-                Some(contract_storage) => {
-                    contract_storage.insert(storage_key, value);
-                }
-                None => {
-                    let mut contract_storage: IndexMap<_, _, _> = Default::default();
-                    contract_storage.insert(storage_key, value);
+            // match commitment_state_diff.storage_diffs.get_mut(&contract_address) {
+            //     Some(contract_storage) => {
+            //         contract_storage.insert(storage_key, value);
+            //     }
+            //     None => {
+            //         let mut contract_storage: IndexMap<_, _, _> = Default::default();
+            //         contract_storage.insert(storage_key, value);
 
-                    commitment_state_diff.storage_diffs.insert(contract_address, contract_storage);
-                }
-            }
-            accessed_addrs.insert(contract_address);
+            //         commitment_state_diff.storage_diffs.insert(contract_address,
+            // contract_storage);     }
+            // }
+            // accessed_addrs.insert(contract_address);
         } else if prefix == *SN_CONTRACT_CLASS_HASH_PREFIX {
             let contract_address =
                 ContractAddress(PatriciaKey(StarkFelt(full_storage_key.0[32..].try_into().unwrap())));

--- a/crates/client/db/src/bonsai_db.rs
+++ b/crates/client/db/src/bonsai_db.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use bonsai_trie::id::{BasicId, Id};
 use bonsai_trie::{BonsaiDatabase, BonsaiPersistentDatabase, BonsaiStorage, DatabaseKey};
 use kvdb::{DBTransaction, KeyValueDB};
-use sp_core::serde::de;
 use sp_runtime::traits::Block as BlockT;
 use starknet_types_core::hash::{Pedersen, Poseidon};
 
@@ -13,7 +12,7 @@ use crate::error::BonsaiDbError;
 #[derive(Debug)]
 pub enum TrieColumn {
     Class,
-    Contract
+    Contract,
 }
 
 #[derive(Debug)]
@@ -40,7 +39,7 @@ impl TrieColumn {
                 KeyType::Trie => crate::columns::TRIE_BONSAI_CONTRACTS,
                 KeyType::Flat => crate::columns::FLAT_BONSAI_CONTRACTS,
                 KeyType::TrieLog => crate::columns::LOG_BONSAI_CONTRACTS,
-            }
+            },
         }
     }
 }

--- a/crates/client/db/src/lib.rs
+++ b/crates/client/db/src/lib.rs
@@ -105,7 +105,7 @@ pub mod static_keys {
 #[derive(Clone)]
 pub struct BonsaiDbs<B: BlockT> {
     pub contract: Arc<BonsaiDb<B>>,
-    pub class: Arc<BonsaiDb<B>>
+    pub class: Arc<BonsaiDb<B>>,
 }
 
 /// The Madara client database backend
@@ -168,7 +168,7 @@ impl<B: BlockT> Backend<B> {
                 _marker: PhantomData,
                 current_column: TrieColumn::Contract,
             }),
-            class: Arc::new(BonsaiDb { db: kvdb.clone(), _marker: PhantomData, current_column: TrieColumn::Class })
+            class: Arc::new(BonsaiDb { db: kvdb.clone(), _marker: PhantomData, current_column: TrieColumn::Class }),
         };
 
         Ok(Self {

--- a/crates/client/deoxys/src/l2.rs
+++ b/crates/client/deoxys/src/l2.rs
@@ -4,8 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use itertools::Itertools;
-use mc_db::bonsai_db::{BonsaiConfigs, BonsaiDb};
-use mc_db::BonsaiDbs;
+use mc_db::bonsai_db::BonsaiConfigs;
 use mc_storage::OverrideHandle;
 use mp_block::state_update::StateUpdateWrapper;
 use mp_contract::class::{ClassUpdateWrapper, ContractClassData, ContractClassWrapper};
@@ -140,18 +139,19 @@ pub async fn sync<B: BlockT>(
     config: FetchConfig,
     start_at: u64,
     rpc_port: u16,
-    bonsai_dbs: BonsaiConfigs<'_, B>
+    bonsai_dbs: BonsaiConfigs<'_, B>,
 ) {
     update_config(&config);
     let SenderConfig { block_sender, state_update_sender, class_sender, command_sink, overrides } = &mut sender_config;
     let client = SequencerGatewayProvider::new(config.gateway.clone(), config.feeder_gateway.clone(), config.chain_id);
+    let bonsai_dbs = Arc::new(Mutex::new(bonsai_dbs));
     let mut current_block_number = start_at;
     let mut last_block_hash = None;
     let mut got_block = false;
     let mut got_state_update = false;
     let mut last_update_highest_block = tokio::time::Instant::now() - Duration::from_secs(20);
-    if current_block_number <= 1 {
-        let _ = fetch_genesis_state_update(&client, bonsai_dbs).await;
+    if current_block_number == 1 {
+        let _ = fetch_genesis_state_update(&client, Arc::clone(&bonsai_dbs)).await;
     }
     loop {
         if last_update_highest_block.elapsed() > Duration::from_secs(20) {
@@ -170,7 +170,7 @@ pub async fn sync<B: BlockT>(
                     class_sender,
                     current_block_number,
                     rpc_port,
-                    bonsai_dbs,
+                    Arc::clone(&bonsai_dbs),
                 );
                 tokio::join!(block, state_update)
             }
@@ -184,7 +184,7 @@ pub async fn sync<B: BlockT>(
                     class_sender,
                     current_block_number,
                     rpc_port,
-                    bonsai_dbs,
+                    Arc::clone(&bonsai_dbs),
                 )
                 .await,
             ),
@@ -246,7 +246,7 @@ async fn fetch_state_and_class_update<B: BlockT>(
     class_sender: &Sender<ClassUpdateWrapper>,
     block_number: u64,
     rpc_port: u16,
-    bonsai_dbs: BonsaiConfigs<'_, B>,
+    bonsai_dbs: Arc<Mutex<BonsaiConfigs<'_, B>>>,
 ) -> Result<(), String> {
     let state_update = fetch_state_update(&provider, block_number, bonsai_dbs).await?;
     let class_update = fetch_class_update(&provider, &state_update, overrides, block_number, rpc_port).await?;
@@ -271,7 +271,7 @@ async fn fetch_state_and_class_update<B: BlockT>(
 async fn fetch_state_update<B: BlockT>(
     provider: &SequencerGatewayProvider,
     block_number: u64,
-    bonsai_dbs: BonsaiConfigs<'_, B>,
+    bonsai_dbs: Arc<Mutex<BonsaiConfigs<'_, B>>>,
 ) -> Result<StateUpdate, String> {
     let state_update = provider
         .get_state_update(BlockId::Number(block_number))
@@ -285,7 +285,7 @@ async fn fetch_state_update<B: BlockT>(
 
 pub async fn fetch_genesis_state_update<B: BlockT>(
     provider: &SequencerGatewayProvider,
-    bonsai_dbs: BonsaiConfigs<'_, B>
+    bonsai_dbs: Arc<Mutex<BonsaiConfigs<'_, B>>>,
 ) -> Result<StateUpdate, String> {
     println!("Fetching genesis state update");
     let state_update =
@@ -447,7 +447,7 @@ pub fn update_l2(state_update: L2StateUpdate) {
 pub fn verify_l2<B: BlockT>(
     block_number: u64,
     state_update: &StateUpdate,
-    bonsai_dbs: BonsaiConfigs<B>
+    bonsai_dbs: Arc<Mutex<BonsaiConfigs<B>>>,
 ) -> Result<(), String> {
     let state_update_wrapper = StateUpdateWrapper::from(state_update);
 

--- a/crates/client/deoxys/src/lib.rs
+++ b/crates/client/deoxys/src/lib.rs
@@ -11,36 +11,28 @@ pub mod l2;
 pub mod types;
 pub mod utils;
 
-use std::sync::Arc;
-
-use bonsai_trie::{id::BasicId, BonsaiStorage, BonsaiStorageConfig};
+use bonsai_trie::id::BasicId;
+use bonsai_trie::{BonsaiStorage, BonsaiStorageConfig};
 pub use l2::{FetchConfig, SenderConfig};
-use mc_db::{bonsai_db::{BonsaiConfigs, BonsaiDb}, BonsaiDbs};
+use mc_db::bonsai_db::{BonsaiConfigs, BonsaiDb};
+use mc_db::BonsaiDbs;
 use sp_runtime::traits::Block as BlockT;
 use starknet_types_core::hash::{Pedersen, Poseidon};
 pub use utils::{convert, m, utility};
 
 type CommandSink = futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<sp_core::H256>>;
 
-pub fn bonsai_configs<B: BlockT>(backend: Arc<mc_db::Backend<B>>) -> BonsaiConfigs<'static, B> {
+pub fn bonsai_configs<B: BlockT>(bonsai_dbs: &BonsaiDbs<B>) -> BonsaiConfigs<B> {
     let config = BonsaiStorageConfig::default();
 
-    let bonsai_dbs = BonsaiDbs {
-        contract: Arc::clone(backend.bonsai_contract()),
-        class: Arc::clone(backend.bonsai_class())
-    };
+    let contract: BonsaiStorage<BasicId, &BonsaiDb<B>, Pedersen> =
+        BonsaiStorage::<_, _, Pedersen>::new(bonsai_dbs.contract.as_ref(), config.clone())
+            .expect("Failed to create bonsai storage");
+    let class = BonsaiStorage::<_, _, Poseidon>::new(bonsai_dbs.class.as_ref(), config.clone())
+        .expect("Failed to create bonsai storage");
 
-    let mut contract: BonsaiStorage<BasicId, &BonsaiDb<B>, Pedersen> =
-        BonsaiStorage::<_, _, Pedersen>::new(bonsai_dbs.contract.as_ref(), config).expect("Failed to create bonsai storage");
-    let mut class =
-        BonsaiStorage::<_, _, Poseidon>::new(bonsai_dbs.class.as_ref(), config).expect("Failed to create bonsai storage");
-
-    BonsaiConfigs {
-        contract,
-        class,
-    }
+    BonsaiConfigs { contract, class }
 }
-
 
 pub mod starknet_sync_worker {
     use std::sync::Arc;
@@ -58,11 +50,15 @@ pub mod starknet_sync_worker {
         backend: Arc<mc_db::Backend<B>>,
     ) {
         let first_block = utility::get_last_synced_block(rpc_port).await + 1;
-        let bonsai_dbs = bonsai_configs(backend.clone());
+
+        let bonsai_dbs =
+            BonsaiDbs { contract: Arc::clone(backend.bonsai_contract()), class: Arc::clone(backend.bonsai_class()) };
+
+        let bonsai_configs = bonsai_configs(&bonsai_dbs);
 
         let _ = tokio::join!(
             l1::sync(l1_url.clone()),
-            l2::sync(sender_config, fetch_config.clone(), first_block, rpc_port, bonsai_dbs)
+            l2::sync(sender_config, fetch_config.clone(), first_block, rpc_port, bonsai_configs)
         );
     }
 }

--- a/crates/pallets/starknet/src/genesis_loader.rs
+++ b/crates/pallets/starknet/src/genesis_loader.rs
@@ -35,13 +35,15 @@ impl<T: crate::Config> From<GenesisData> for GenesisConfig<T> {
             .storage
             .clone()
             .into_iter()
-            .map(|((contract_address, key), value)| {
+            .map(|(contract_address, storage)| {
                 (
-                    (
-                        ContractAddress(PatriciaKey(StarkFelt(contract_address.0.to_bytes_be()))),
-                        StorageKey(PatriciaKey(StarkFelt(key.0.to_bytes_be()))),
-                    ),
-                    StarkFelt(value.0.to_bytes_be()),
+                    ContractAddress(PatriciaKey(StarkFelt(contract_address.0.to_bytes_be()))),
+                    storage
+                        .into_iter()
+                        .map(|(key, value)| {
+                            (StorageKey(PatriciaKey(StarkFelt(key.0.to_bytes_be()))), StarkFelt(value.0.to_bytes_be()))
+                        })
+                        .collect(),
                 )
             })
             .collect();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Local db [only stores contract storage diff values](https://github.com/KasarLabs/deoxys/blob/9cb45f18c961c2783e619dd8cd4d8cfaae10da01/crates/pallets/starknet/src/lib.rs#L229), with the contract address and the storage key as the db key.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Now full contract storage diffs in the local db as a key-value vector with the contract address as te 

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No
