### PR TITLE
feat: :sparkles: add_*_transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Madara Changelog
 
 ## Next release
 
+- feat(rpc): add_invoke_tx, add_deploy_account_tx, add_declare_tx
 - feat(rpc): tx_receipt, re-execute tx
 - feat(script): added CI scripts for starting Deoxys and comparing JSON RPC
   calls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6084,6 +6084,7 @@ dependencies = [
  "sp-runtime",
  "starknet-core",
  "starknet-ff 0.3.5 (git+https://github.com/jbcaron/starknet-rs.git?branch=classes)",
+ "starknet-providers",
  "starknet_api",
  "thiserror",
  "tokio",

--- a/crates/client/rpc/Cargo.toml
+++ b/crates/client/rpc/Cargo.toml
@@ -44,6 +44,7 @@ blockifier = { workspace = true, default-features = true }
 starknet-core = { workspace = true }
 starknet-ff = { workspace = true }
 starknet_api = { workspace = true, default-features = true }
+starknet-providers = { workspace = true }
 # Others
 anyhow = { workspace = true }
 hex = { workspace = true, default-features = true }

--- a/crates/client/rpc/src/errors.rs
+++ b/crates/client/rpc/src/errors.rs
@@ -1,5 +1,6 @@
 use jsonrpsee::types::error::{CallError, ErrorObject};
 use pallet_starknet_runtime_api::StarknetTransactionExecutionError;
+use starknet_core::types::StarknetError;
 
 // Comes from the RPC Spec:
 // https://github.com/starkware-libs/starknet-specs/blob/0e859ff905795f789f1dfd6f7340cdaf5015acc8/api/starknet_write_api.json#L227
@@ -11,6 +12,10 @@ pub enum StarknetRpcApiError {
     ContractNotFound = 20,
     #[error("Block not found")]
     BlockNotFound = 24,
+    #[error("Invalid transaction hash")]
+    InvalidTxnHash = 25,
+    #[error("Invalid tblock hash")]
+    InvalidBlockHash = 26,
     #[error("Invalid transaction index in a block")]
     InvalidTxnIndex = 27,
     #[error("Class hash not found")]
@@ -29,14 +34,36 @@ pub enum StarknetRpcApiError {
     FailedToFetchPendingTransactions = 38,
     #[error("Contract error")]
     ContractError = 40,
+    #[error("Transaction execution error")]
+    TxnExecutionError = 41,
     #[error("Invalid contract class")]
     InvalidContractClass = 50,
     #[error("Class already declared")]
     ClassAlreadyDeclared = 51,
+    #[error("Invalid transaction nonce")]
+    InvalidTxnNonce = 52,
+    #[error("Max fee is smaller than the minimal transaction cost (validation plus fee transfer)")]
+    InsufficientMaxFee = 53,
+    #[error("Account balance is smaller than the transaction's max_fee")]
+    InsufficientAccountBalance = 54,
     #[error("Account validation failed")]
     ValidationFailure = 55,
+    #[error("Compilation failed")]
+    CompilationFailed = 56,
+    #[error("Contract class size is too large")]
+    ContractClassSizeTooLarge = 57,
+    #[error("Sender address is not an account contract")]
+    NonAccount = 58,
+    #[error("A transaction with the same hash already exists in the mempool")]
+    DuplicateTxn = 59,
+    #[error("The compiled class hash did not match the one supplied in the transaction")]
+    CompiledClassHashMismatch = 60,
     #[error("The transaction version is not supported")]
-    UnsupportedTxVersion = 61,
+    UnsupportedTxnVersion = 61,
+    #[error("The contract class version is not supported")]
+    UnsupportedContractClassVersion = 62,
+    #[error("An unexpected error occurred")]
+    ErrUnexpectedError = 63,
     #[error("Internal server error")]
     InternalServerError = 500,
     #[error("Unimplemented method")]
@@ -60,5 +87,38 @@ impl From<StarknetTransactionExecutionError> for StarknetRpcApiError {
 impl From<StarknetRpcApiError> for jsonrpsee::core::Error {
     fn from(err: StarknetRpcApiError) -> Self {
         jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(err as i32, err.to_string(), None::<()>)))
+    }
+}
+
+impl From<StarknetError> for StarknetRpcApiError {
+    fn from(err: StarknetError) -> Self {
+        match err {
+            StarknetError::FailedToReceiveTransaction => StarknetRpcApiError::FailedToReceiveTxn,
+            StarknetError::ContractNotFound => StarknetRpcApiError::ContractNotFound,
+            StarknetError::BlockNotFound => StarknetRpcApiError::BlockNotFound,
+            StarknetError::InvalidTransactionIndex => StarknetRpcApiError::InvalidTxnIndex,
+            StarknetError::ClassHashNotFound => StarknetRpcApiError::ClassHashNotFound,
+            StarknetError::TransactionHashNotFound => StarknetRpcApiError::TxnHashNotFound,
+            StarknetError::PageSizeTooBig => StarknetRpcApiError::PageSizeTooBig,
+            StarknetError::NoBlocks => StarknetRpcApiError::NoBlocks,
+            StarknetError::InvalidContinuationToken => StarknetRpcApiError::InvalidContinuationToken,
+            StarknetError::TooManyKeysInFilter => StarknetRpcApiError::TooManyKeysInFilter,
+            StarknetError::ContractError(_) => StarknetRpcApiError::ContractError,
+            StarknetError::ClassAlreadyDeclared => StarknetRpcApiError::ClassAlreadyDeclared,
+            StarknetError::InvalidTransactionNonce => StarknetRpcApiError::InvalidTxnNonce,
+            StarknetError::InsufficientMaxFee => StarknetRpcApiError::InsufficientMaxFee,
+            StarknetError::InsufficientAccountBalance => StarknetRpcApiError::InsufficientAccountBalance,
+            StarknetError::ValidationFailure => StarknetRpcApiError::ValidationFailure,
+            StarknetError::CompilationFailed => StarknetRpcApiError::CompilationFailed,
+            StarknetError::ContractClassSizeIsTooLarge => StarknetRpcApiError::ContractClassSizeTooLarge,
+            StarknetError::NonAccount => StarknetRpcApiError::NonAccount,
+            StarknetError::DuplicateTx => StarknetRpcApiError::DuplicateTxn,
+            StarknetError::CompiledClassHashMismatch => StarknetRpcApiError::CompiledClassHashMismatch,
+            StarknetError::UnsupportedTxVersion => StarknetRpcApiError::UnsupportedTxnVersion,
+            StarknetError::UnsupportedContractClassVersion => StarknetRpcApiError::UnsupportedContractClassVersion,
+            StarknetError::UnexpectedError(_) => StarknetRpcApiError::ErrUnexpectedError,
+            StarknetError::NoTraceAvailable(_) => StarknetRpcApiError::InternalServerError,
+            StarknetError::InvalidTransactionHash => StarknetRpcApiError::InvalidTxnHash,
+        }
     }
 }


### PR DESCRIPTION
send the execution request to the sequencer, add error codes

# Pull Request type

- Feature

## What is the current behavior?


## What is the new behavior?

- Added execution calls (add) RPC.

## Does this introduce a breaking change?

No

## Other information

- needs to add error codes and perform tests on the error codes
